### PR TITLE
Make transport logic more reliable

### DIFF
--- a/src/rodi_robot/main.py
+++ b/src/rodi_robot/main.py
@@ -54,9 +54,11 @@ class RodiRobot(object):
                 self.transport.stop()
                 self.last_cmd_vel = rospy.Time.now()
             try:
-                self.us_sensor.range = float(self.transport.see()) / 100.0
-                self.us_sensor.header.stamp = rospy.Time.now()
-                self.pub.publish(self.us_sensor)
+                range = self.transport.see()
+                if range is not None:
+                    self.us_sensor.range = float(range) / 100.0
+                    self.us_sensor.header.stamp = rospy.Time.now()
+                    self.pub.publish(self.us_sensor)
             except Exception as exception:
                 rospy.logerr("getting sonar data failed: " + str(exception))
 

--- a/src/rodi_robot/main.py
+++ b/src/rodi_robot/main.py
@@ -24,7 +24,7 @@ class RodiRobot(object):
                                    Range,
                                    queue_size=1)
 
-        self.rate = rospy.Rate(2)  # 2 Hz
+        self.rate = rospy.Rate(1)  # 1 Hz
 
         self.us_sensor = Range()
         self.us_sensor.radiation_type = 0  # ULTRASOUND

--- a/src/rodi_robot/transport.py
+++ b/src/rodi_robot/transport.py
@@ -16,7 +16,7 @@ class Transport(object):
         try:
             self.conn = HTTPConnection(self.hostname,
                                        port=self.port,
-                                       timeout=1.0)
+                                       timeout=0.5)
             self.conn.request("GET", request)
             response = self.conn.getresponse().read()
             self.conn.close()

--- a/src/rodi_robot/transport.py
+++ b/src/rodi_robot/transport.py
@@ -20,6 +20,8 @@ class Transport(object):
             self.conn.request("GET", request)
             response = self.conn.getresponse().read()
             self.conn.close()
+            if len(response) == 0:
+                return None
             return response
         except Exception as e:
             logerr("the HTTP request failed: " + str(e))

--- a/src/rodi_robot/transport.py
+++ b/src/rodi_robot/transport.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from rospy import logerr
+from rospy import logdebug
 from httplib import HTTPConnection
 
 
@@ -24,7 +24,7 @@ class Transport(object):
                 return None
             return response
         except Exception as e:
-            logerr("the HTTP request failed: " + str(e))
+            logdebug("the HTTP request " + request + " failed: " + str(e))
             return None
 
     def move_forward(self):

--- a/src/rodi_robot/transport.py
+++ b/src/rodi_robot/transport.py
@@ -23,7 +23,7 @@ class Transport(object):
             return response
         except Exception as e:
             logerr("the HTTP request failed: " + str(e))
-            return 0
+            return None
 
     def move_forward(self):
         self.send_command([3, 100, 100])


### PR DESCRIPTION
The rodi_robot package transport doesn't work too well, RoDI isn't able to cope with the request rate under heavy load and a lot of HTTP requests timeout.

These patches attempts to improve the situation, making the transport layer more robust.

@garyservin, could you please review/test these changes and merge them if you agree with them? Thanks a lot!